### PR TITLE
Fix README to install the bundle only in dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can learn more in the [documentation for the standalone library](https://git
 ## Installation
 
 ```bash
-composer require trappar/alice-generator-bundle
+composer require --dev trappar/alice-generator-bundle
 ```
 
 Then, enable the bundle by updating your `app/AppKernel.php` file to enable the bundle:


### PR DESCRIPTION
Perhaps, it is better to avoid installing this dependency in production environments and only install it in development environments. In the AppKernel it is only loaded in  "dev" oi "test" environments, following the concerted approach if it is not used in production environment also avoid installing.