### PR TITLE
Change chain_driver service to public

### DIFF
--- a/src/Trappar/AliceGeneratorBundle/Resources/config/services.yml
+++ b/src/Trappar/AliceGeneratorBundle/Resources/config/services.yml
@@ -13,7 +13,7 @@ services:
         arguments: ['@annotation_reader']
 
     trappar_alice_generator.metadata.chain_driver:
-        public: false
+        public: public
         class: Metadata\Driver\DriverChain
         arguments:
             - ['@Trappar\AliceGenerator\Metadata\Driver\YamlDriver', '@Trappar\AliceGenerator\Metadata\Driver\AnnotationDriver']


### PR DESCRIPTION
This bundle currently doesn't work with Symfony 3.4 and 4.x as it throws
the following error:

`The "trappar_alice_generator.metadata.chain_driver" service or alias
has been removed or inlined when the container was compiled. You should
either make it public, or stop using the container directly and use
dependency injection instead.`

Fixes https://github.com/trappar/AliceGeneratorBundle/issues/7